### PR TITLE
Add support for styled tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,23 @@ from htmldocx import HtmlToDocx
 new_parser = HtmlToDocx()
 docx = new_parser.parse_html_string(input_html_file_string)
 ```
+
+Change table styles
+
+Tables are not styled by default. Use the `table_style` attribute on the parser to set a table
+style. The style is used for all tables.
+
+```
+from htmldocx import HtmlToDocx
+
+new_parser = HtmlToDocx()
+new_parser.table_style = 'Light Shading Accent 4'
+```
+
+To add borders to tables, use the `TableGrid` style:
+
+```
+new_parser.table_style = 'TableGrid'
+```
+
+Default table styles can be found here: https://python-docx.readthedocs.io/en/latest/user/styles-understanding.html#table-styles-in-default-template

--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -30,6 +30,9 @@ INDENT = 0.25
 LIST_INDENT = 0.5
 MAX_INDENT = 5.5 # To stop indents going off the page
 
+# Style to use with tables. By default no style is used.
+DEFAULT_TABLE_STYLE = None
+
 def get_filename_from_url(url):
     return os.path.basename(urlparse(url).path)
 
@@ -96,6 +99,7 @@ class HtmlToDocx(HTMLParser):
             'table > tbody > tr',
             'table > tfoot > tr'
         ]
+        self.table_style = DEFAULT_TABLE_STYLE
 
     def set_initial_attrs(self, document=None):
         self.tags = {
@@ -115,6 +119,10 @@ class HtmlToDocx(HTMLParser):
         self.skip = False
         self.skip_tag = None
         self.instances_to_skip = 0
+
+    def copy_settings_from(self, other):
+        """Copy settings from another instance of HtmlToDocx"""
+        self.table_style = other.table_style
 
     def get_cell_html(self, soup):
         # Returns string of td element with opening and closing <td> tags removed
@@ -237,6 +245,13 @@ class HtmlToDocx(HTMLParser):
         table_soup = self.tables[self.table_no]
         rows, cols = self.get_table_dimensions(table_soup)
         self.table = self.doc.add_table(rows, cols)
+
+        if self.table_style:
+            try:
+                self.table.style = self.table_style
+            except KeyError as e:
+                raise ValueError(f"Unable to apply style {self.table_style}.") from e
+
         rows = self.get_table_rows(table_soup)
         cell_row = 0
         for row in rows:
@@ -248,6 +263,7 @@ class HtmlToDocx(HTMLParser):
                     cell_html = "<b>%s</b>" % cell_html
                 docx_cell = self.table.cell(cell_row, cell_col)
                 child_parser = HtmlToDocx()
+                child_parser.copy_settings_from(self)
                 child_parser.add_html_to_cell(cell_html, docx_cell)
                 cell_col += 1
             cell_row += 1

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -6,4 +6,6 @@ from .context import HtmlToDocx, test_dir
 filename = os.path.join(test_dir, 'tables2.html')
 d = HtmlToDocx()
 
+d.table_style = 'Light Grid Accent 6'
+
 d.parse_html_file(filename)


### PR DESCRIPTION
Allow table style to be changed by setting table_style attribute on the
HtmlToDocx instance.

The default table style is set to None to ensure the behavior doesn't
change between versions.

Available default styles can be found here:

https://python-docx.readthedocs.io/en/latest/user/styles-understanding.html#table-styles-in-default-template

Example usage:

```python
d = HtmlToDocx()
d.table_style = 'Light Grid Accent 6'
```

Add copy_settings_from function to support copying settings between instances.

Add documentation to the readme.