### PR TITLE
Add handling for pre and code blocks

### DIFF
--- a/tests/code.html
+++ b/tests/code.html
@@ -1,0 +1,27 @@
+<h1>Code Test</h1>
+
+<p>This test validates handling of code blocks.</p>
+
+<h2>Pre-formatted block</h2>
+
+<pre>
+This is a pre-formatted block.
+  That should be pre-formatted.
+Retaining any carriage returns, and     all    white    space.
+
+And blank lines.
+</pre>
+
+<h2>Code block</h2>
+
+<p><code>
+This is a code block.
+  That should be NOT be pre-formatted.
+It should NOT retain carriage returns, or     all    white    space.
+
+or blank lines.
+</code></p>
+
+<h2>Code elements</h2>
+
+<p>This is a sentence that includes <code>code</code> elements.</p>

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,0 +1,9 @@
+import os
+from .context import HtmlToDocx, test_dir
+
+# Manual test (requires inspection of result) for converting code and pre blocks.
+
+filename = os.path.join(test_dir, 'code.html')
+d = HtmlToDocx()
+
+d.parse_html_file(filename)


### PR DESCRIPTION
Pre and code blocks use Courier font.
Pre blocks retain white space and new line characters.

Code blocks should shouldn't retain white space and new lines,
however the remove_whitespace function doesn't squash multiple
spaces, which it probably should.

Add manual test for code blocks. Run this manually to validate
visual representation of code and pre-formatted blocks.